### PR TITLE
docs: add rough agenda

### DIFF
--- a/2020/06-16.md
+++ b/2020/06-16.md
@@ -14,3 +14,8 @@ Please add topics you would like from the proposals from the [current charter](h
 ## Agenda items
 
 * An update on UUID ~ Benjamin Coe
+  * Refresher.
+  * Topics of Feedback:
+    * Initial API design.
+    * Relationship to CSPRNG.
+    * Advise on Spec text.


### PR DESCRIPTION
Adds a rough agenda, reflected in [slides here](https://drive.google.com/file/d/17tbAfV6WS3pVm_9v8JUEU4et4mNlLvwi/view?usp=sharing).