### PR TITLE
Add agenda for 2023-11/12 call on Stable Formatting

### DIFF
--- a/2023/11-xx.md
+++ b/2023/11-xx.md
@@ -1,0 +1,24 @@
+# Agenda for Ecma TC39 Incubator Call
+
+- **Date & Time**: TBD, see [Doodle poll](https://doodle.com/meeting/participate/id/dBnGrGQd)
+- **Attendee information**: [Reflector](https://github.com/tc39/Reflector/issues/513)
+- **Call** TBD
+
+## Agenda items
+
+A call focusing on the [Stable Formatting proposal](https://github.com/tc39/proposal-stable-formatting/).
+
+### Stable Formatting
+
+The proposal currently presents two alternative paths for its progress:
+
+1. Add support for a new "null" locale to ECMA-402 Intl formatters and functions.
+   This would be a general solution to the problems presented in the proposal,
+   but it would extend the scope of Intl to cover some non-localization use cases.
+
+2. Add new options and methods to ECMA-262 functions and objects.
+   This approach would be more surgical,
+   identifying specific cases where functionality should be added to the language
+
+We need to discuss which approach to take,
+and what each of the approaches would look like in more detail.


### PR DESCRIPTION
Adding as a draft until the dates are settled via the [Doodle poll](https://doodle.com/meeting/participate/id/dBnGrGQd).

The proposed agenda is [here](https://github.com/eemeli/tc39-incubator-agendas/blob/add-stable-formatting/2023/11-xx.md).

I'm hoping to be able to pick the meeting date & time by Wednesday 22 November.